### PR TITLE
Fixed material issue causing menu dropdown text being cut off

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -232,3 +232,8 @@ html  {
     background: orange;
     border-radius: 1em;
 }
+
+ul .dropdown-content {
+    /* Override default material settings causing dropdown menu item text to be cut off */
+    width: auto !important; 
+}


### PR DESCRIPTION
* Currently the dropdown menu text is being cut off in most browsers, this is due to a default width being set my the material library. The below code fixes this and allows the menu to grow according to the content. 
* `max-width` and `overflow` properties could be set here in future if required.