### PR TITLE
added content and style to about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -53,7 +53,196 @@
             </nav>
         </div>
     </header>
-    <div class="container">
-        <h2>Happy Hacking Open Source Contrbutors Round the World!!!</h2>
+<div class="container">
+    <div class="details">
+        <h1 id="getting-started" class="title is-1"><a href="#getting-started">Getting started with Hacktoberfest</a>
+        </h1>
+        <p>We ask all participants to read through the details to
+            ensure that the global community is working toward a shared
+            goal. Thanks for honoring the values and following the rules
+            of participation.</p>
     </div>
+    <div class="details-tabs">
+        <div class="box">
+            <div id="tab1C" class="tab-block" style="">
+                <div class="container">
+                    <p>If you’re new to open source (everyone was once!),
+                        take a look at our </p> <a
+                        href="https://www.digitalocean.com/community/tutorial_series/an-introduction-to-open-source">Introduction
+                        to Open Source series.</a>
+                    <p>Before you make your first contribution, you should
+                        familiarize yourself with
+                        <a
+                            href="https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github">
+                            How To Create a Pull Request</a>.</p>
+                    <p>The following resources share repositories that curate tasks for beginners:</p>
+                    <p> <span class="highlight">●</span> <a href="https://up-for-grabs.net/#/"> Up For Grabs</a> </p>
+                    <p> <span class="highlight">●</span> <a href="http://issuehub.io/"> Issuehub.io</a> </p>
+                    <p> <span class="highlight">●</span> <a href="https://www.firsttimersonly.com/"> First Timers
+                            Only</a> </p>
+                    <p> <span class="highlight">●</span> <a href="http://yourfirstpr.github.io/"> Your First PR</a> </p>
+                    <p> <span class="highlight">●</span> <a href="https://github.com/mungell/awesome-for-beginners">
+                            Awesome for Beginners</a> </p>
+                    <p>Once you start feeling more comfortable, you can find more open source
+                        projects through the following programs: </p>
+                    <p> <span class="highlight">●</span> <a href="http://www.pullrequestroulette.com/"> Pull Request
+                            Roulette</a> </p>
+                    <p> <span class="highlight">●</span> <a href="https://www.codetriage.com/"> Code Triage</a> </p>
+                    <p> <span class="highlight">●</span> <a href="https://24pullrequests.com/"> 24 P[ull] R[equest]s
+                        </a> </p>
+                    <p> <span class="highlight">●</span> <a href="https://opensource.guide/how-to-contribute/">This is
+                            another great guide</a> outlining ways you can contribute to open source.</p>
+                </div>
+
+            </div>
+            <div id="tab2C" class="tab-block" style="display: none;">
+                <div class="container">
+                    <div class="container">
+                        <p>Recommendations for creating a good Hacktoberfest issue in your project:</p>
+                        <p> <span class="highlight">●</span> <a
+                                href="https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/">
+                                Apply the "Hacktoberfest" label</a>
+                            to issues in your GitHub project that are ready for new contributors to work on.</p>
+                        <p> <span class="highlight">●</span> Add a CONTRIBUTING.md file with
+                            contribution guidelines to your repo.</p>
+                        <p> <span class="highlight">●</span> Choose issues that have a well-defined
+                            scope and are self-contained.</p>
+                        <p> <span class="highlight">●</span> Adopt a code of conduct to foster a
+                            greater sense of inclusion and community.</p>
+                    </div>
+                </div>
+
+            </div>
+            <div id="tab3C" class="tab-block" style="display: none;">
+                <div class="container">
+                    <p>Organizing a Hacktoberfest event in October is a great way to support the
+                        open source community.</p>
+                    <p>Last year, 267 events were organized in 50 countries. This year,
+                        let’s work together to bring this celebration to even more people
+                        around the world! Explore the
+                        <a href="/eventkit">Hacktoberfest Event Kit</a> to learn about how to successfully organize a
+                        gathering in
+                        your community.</p>
+                    <p>Get exposure for your event and swag to share with your attendees. <a
+                            href="/eventkit#form">Submit here</a>.</p>
+                </div>
+
+            </div>
+            <div id="tab4C" class="tab-block" style="display: none;">
+                <div class="container">
+                    <p>Hacktoberfest is a great fit for technology companies looking to increase
+                        participation in their open source projects. </p>
+                    <p>Your company can participate by encouraging people to contribute to your
+                        repositories, organizing community events, or engaging internal employees.</p>
+                    <p>Logos from participating companies are displayed on the official
+                        Hacktoberfest website to showcase your support of open source.</p>
+                    <p>Our friends at SendGrid wrote <a
+                            href="https://sendgrid.com/wp-content/uploads/pdf/SendGrid-Hacktoberfest.pdf">this guide
+                        </a>outlining how they used
+                        Hacktoberfest to increase their open source contributions by 3,510%.
+                        They also talked <a href="https://devrel.net/community/surviving-hacktoberfest">about this
+                            growth </a>at DevRelCon.</p>
+                </div>
+
+            </div>
+        </div>
+
+    </div>
+
+    <div class="container details">
+        <h1 id="event-details" class="title is-1"><a href="#event-details">Event details</a></h1>
+        <p><span class="highlight">●</span> Hacktoberfest is open to everyone in our global community!</p>
+        <p><span class="highlight">●</span> Pull requests can be made in any GitHub-hosted repositories/projects.</p>
+        <p><span class="highlight">●</span> You can sign up anytime between October 1 and October 31.</p>
+    </div>
+
+    <div class="container details">
+        <h1 id="participation-rules" class="title is-1"><a href="#participation-rules">Participation rules</a></h1>
+        <p>To qualify for the official limited edition Hacktoberfest shirt,
+            you must register and then make four pull requests (PRs) between
+            October 1-31 (in any time zone). PRs can be made to any public
+            repo on GitHub, not only the ones with issues labeled Hacktoberfest.
+            If a maintainer reports your pull request as spam or behavior not in
+            line with the project’s code of conduct, you will be ineligible to
+            participate. This year, the first 50,000 participants who successfully
+            complete the challenge will earn a T-shirt. (Last year 46,088
+            earned a shirt!)</p>
+    </div>
+
+    <div class="container details">
+        <h1 id="quality-standards" class="title is-1"><a href="#quality-standards">Quality standards</a></h1>
+        <p>In line with Hacktoberfest value #2 (Quantity is fun,
+            quality is key), here are examples of the PRs that we
+            consider to be low-quality contributions (which we discourage).</p>
+        <p><span class="highlight">●</span> PRs that are automated (e.g. scripted opening PRs to remove
+            whitespace/optimize images)</p>
+        <p><span class="highlight">●</span> PRs that are disruptive (e.g. taking someone else's branch/commits and
+            making
+            a PR) </p>
+        <p><span class="highlight">●</span> PRs that are regarded by a project maintainer as a hindrance vs. helping</p>
+        <p><span class="highlight">●</span> Something that's clearly an attempt to simply +1 your PR count for October
+        </p>
+        <p><span class="highlight">●</span> Last but not least, one PR to fix a typo is fine. 5 PRs to remove a stray
+            whitespace... not. </p>
+    </div>
+
+    <div class="container details">
+        <h1 id="values" class="title is-1"><a href="#values">Values</a></h1>
+        <p>Inspired by you – the community – through your actions and stories.</p>
+        <p><span class="highlight">●</span> <b>Everyone is welcome!</b> Hacktoberfest participants
+            have represented 151 countries and thousands of unique skill sets. Our
+            program welcomes everyone already in the open source software community – and
+            anyone interested in diving in.</p>
+        <p><span class="highlight">●</span> <b>Quantity is fun, quality is key!</b> Participating
+            in Hacktoberfest leads to personal growth, professional opportunities, and
+            community building. And it all begins with meaningful contributions to
+            open source technology.</p>
+        <p><span class="highlight">●</span> <b>Short-term actions, long-term impact!</b> In the
+            open source community, we stand on the shoulders of those who came before
+            us. Your participation has a lasting effect on people and technology long
+            after October comes to an end. This is a voyage, not a race.</p>
+    </div>
+
+    <div class="container details">
+        <h1 id="spam" class="title is-1"><a href="#spam">Let’s work together to reduce spam</a></h1>
+        <p>
+            <span class="highlight">●</span> <b>Spammy PRs can be labeled as “invalid.” </b>
+            Maintainers are faced with the majority of spam that occurs during Hacktoberfest, and we dislike spam just
+            as
+            much as you. If you’re a maintainer, please label any spammy PRs submitted to the repositories you maintain
+            as
+            <b>invalid</b>, and close them. PRs with this label won't count toward Hacktoberfest.
+        </p>
+        <p>
+            <span class="highlight">●</span> <b>There’s a seven-day review window for PRs. </b>
+            This year, we've implemented a new seven-day grace period that all PRs for Hacktoberfest must go through
+            before
+            they count toward completing the challenge. Once a participant has submitted four eligible PRs
+            (ready-to-review,
+            not drafts), the review window begins. This period gives maintainers time to identify and label spammy PRs
+            as
+            <b>invalid</b>. If the PRs are not marked <b>invalid</b> within that window, they will allow the user to
+            complete the Hacktoberfest challenge. If any of the PRs are labeled as <b>invalid</b>, however, the user
+            will
+            return to the pending state until they have four eligible PRs, at which point the review period will then
+            start
+            again.
+        </p>
+        <p>
+            <span class="highlight">●</span> <b>Bad repositories will be excluded. </b>
+            In the past, we've seen many repositories that encourage participants to make simple PRs – such as adding
+            their
+            name to a file – to quickly gain a PR toward winning Hacktoberfest. While this may be a learning tool for
+            new
+            contributors, it goes against one of our core values for Hacktoberfest. The quality of pull requests is
+            paramount; quantity comes second. These repositories do not encourage quality contributions and provide an
+            unfair advantage in completing the Hacktoberfest challenge. This year, we've implemented a system to block
+            these
+            repositories, and any pull requests submitted to such repositories will not be counted. If you’d like to
+            report
+            a repository, please email us at
+            <a href="mailto:hacktoberfest@digitalocean.com">Hacktoberfest@DigitalOcean.com</a>.
+        </p>
+    </div>
+</div>
 </body>

--- a/css/styles.css
+++ b/css/styles.css
@@ -277,3 +277,18 @@ nav ul a:hover {
     background-color: rgba(0, 0, 0, 0.1);
     color: white;
 }
+
+body .container {
+    margin: auto;
+}
+
+.details,
+.container.details {
+    margin-bottom: 60px;
+}
+
+.container {
+    flex-grow: 1;
+    margin: 0 auto;
+    position: relative;
+}


### PR DESCRIPTION
This PR's aim is to add some content regarding the Hacktoberfest to the about page in this repo.

Here below is a visual result of these changes.

![screencapture-127-0-0-1-5500-about-html-2019-10-02-10_40_00](https://user-images.githubusercontent.com/21361479/66030142-069a1500-e501-11e9-8d58-e218bff2834e.png)
