### PR TITLE
Clear .vscode from git catch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "liveServer.settings.port": 5501
-}


### PR DESCRIPTION
Fixes: https://github.com/Evie-Skinner18/happy_hacktoberfest_19/issues/197 


Problem lays in adding .gitignore after already comitting files to the ignored directory, making the .gitignore unfunctional. 

This is solved by `git rm -r --cached .vscode` and then committing the folder updates.